### PR TITLE
コマンド名を変更

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ jobs:
   release:
     runs-on: ${{ matrix.config.os }}
     env:
-      PROJECT_NAME: point_tiler
+      PROJECT_NAME: ptiler
     strategy:
       fail-fast: false
       matrix:
@@ -87,8 +87,8 @@ jobs:
 
       - name: Rename artifact
         run: |
-          ls -lh ./target/${{ matrix.config.target }}/release/app${{ matrix.config.extension }}
-          mv ./target/${{ matrix.config.target }}/release/app${{ matrix.config.extension }} \
+          ls -lh ./target/${{ matrix.config.target }}/release/ptiler${{ matrix.config.extension }}
+          mv ./target/${{ matrix.config.target }}/release/ptiler${{ matrix.config.extension }} \
              ./target/${{ matrix.config.target }}/release/${{ env.PROJECT_NAME }}-${{ github.ref_name }}-${{ matrix.config.target }}${{ matrix.config.extension }}
         shell: bash
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -76,7 +76,7 @@ Rust をインストールした後、このリポジトリをダウンロード
 ### 使用例
 
 ```sh
-point_tiler --input app/examples/data/sample.las \
+ptiler --input app/examples/data/sample.las \
     --output app/examples/data/output \
     --input-epsg 6677 \
     --output-epsg 4979 \
@@ -98,7 +98,7 @@ point_tiler --input app/examples/data/sample.las \
 **実行コマンド:**
 
 ```sh
-point_tiler --input /path/to/data/*.las \
+ptiler --input /path/to/data/*.las \
     --output /path/to/output \
     --input-epsg 6677 \
     --output-epsg 4979 \

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ After installing Rust, download this repository.
 ### Example
 
 ```sh
-point_tiler --input app/examples/data/sample.las \
+ptiler --input app/examples/data/sample.las \
     --output app/examples/data/output \
     --input-epsg 6677 \
     --output-epsg 4979 \
@@ -98,7 +98,7 @@ point_tiler --input app/examples/data/sample.las \
 **Command:**
 
 ```sh
-point_tiler --input /path/to/data/*.las \
+ptiler --input /path/to/data/*.las \
     --output /path/to/output \
     --input-epsg 6677 \
     --output-epsg 4979 \

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -4,6 +4,10 @@ edition = "2021"
 version.workspace = true
 authors.workspace = true
 
+[[bin]]
+name = "ptiler"
+path = "src/main.rs"
+
 [dependencies]
 pcd-parser = { path = "../pcd-parser" }
 cesiumtiles-gltf = { path = "../cesiumtiles-gltf" }

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@ __wrap__() {
 
 REPO=MIERUNE/point-tiler
 
-VERSION=${POINT_TILER_VERSION:-latest}
+VERSION=${PTILER_VERSION:-latest}
 
 if ! command -v curl > /dev/null 2>&1; then
   echo "Error: 'curl' is required but not installed. Please install it and try again."
@@ -41,18 +41,18 @@ else
   exit 1
 fi
 
-BINARY="point_tiler-${VERSION}-${ARCH}-${PLATFORM}"
+BINARY="ptiler-${VERSION}-${ARCH}-${PLATFORM}"
 
 DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${VERSION}/${BINARY}"
 
-echo "This script will automatically download and install point_tiler (${VERSION}) for you."
+echo "This script will automatically download and install ptiler (${VERSION}) for you."
 
 if [ "x$(id -u)" == "x0" ]; then
   echo "Warning: this script is running as root. This is dangerous and unnecessary!"
 fi
 
 TEMP_DIR=$(mktemp -d)
-TEMP_FILE="$TEMP_DIR/point_tiler"
+TEMP_FILE="$TEMP_DIR/ptiler"
 cleanup() {
   rm -rf "$TEMP_DIR"
 }
@@ -73,10 +73,10 @@ if [[ ! -w $INSTALL_DIR ]]; then
   echo "Please run the script with appropriate permissions or install to a directory you have write access to."
   exit 1
 fi
-mv "$TEMP_FILE" "$INSTALL_DIR/point_tiler"
+mv "$TEMP_FILE" "$INSTALL_DIR/ptiler"
 
 
-echo "point_tiler has been installed successfully to $INSTALL_DIR/point_tiler"
+echo "ptiler has been installed successfully to $INSTALL_DIR/ptiler"
 }
 
 __wrap__


### PR DESCRIPTION
<!-- Close or Related Issues -->
Close #0

### What I did
<!-- Please describe the motivation behind this PR and the changes it introduces. -->

  CLIコマンド名を `point_tiler` から `ptiler` に短縮。

  - `app/Cargo.toml` に `[[bin]]` セクションを追加してバイナリ名を `ptiler` に設定
  - リリースワークフロー・インストールスクリプト・READMEの参照を更新
  - インストールスクリプトの環境変数名を `POINT_TILER_VERSION` → `PTILER_VERSION` に変更

### Notes
<!-- If manual testing is required, please describe the procedure. -->

